### PR TITLE
Continue on `strip.y() < 0` in `generate_commands`

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -129,12 +129,12 @@ impl RenderContext {
         for i in 0..self.strip_buf.len() - 1 {
             let strip = &self.strip_buf[i];
 
-            if strip.x() >= self.width as i32 {
+            if strip.x() >= self.width as i32 || strip.y() < 0 {
                 // Don't render strips that are outside the viewport.
                 continue;
             }
 
-            if strip.y() >= self.height as i32 || strip.y() < 0 {
+            if strip.y() >= self.height as i32 {
                 // Since strips are sorted by location, any subsequent strips will also be
                 // outside the viewport, so we can abort entirely.
                 break;


### PR DESCRIPTION
I'm just trying out the code and spotted this; you may have other things in mind here.

Strips with `y < 0` are not currently generated: they are filtered out at the tile-level for paths, and the rectangle fast-path currently clamps to unsigned `u32`.

If strips with `y < 0` do make it here, removing the check altogether makes the command generation crash, but the better choice is probably to skip rather than break out of the loop: other strips that are inside the viewport may still be in the buffer and will be sorted after this one.